### PR TITLE
Project自動追加を--owner @me + GraphQLフォールバックに修正

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,6 +6,11 @@
 #   classic PAT（scope: repo + project）を作成し、
 #   本repoの Settings → Secrets and variables → Actions に
 #   ADD_TO_PROJECT_PAT という名前で登録する
+#
+# 実装メモ: --owner にログイン名を渡すと gh 内部のオーナー種別判定が
+# unknown owner type で失敗することがあるため（scope・トークン種別は正常でも発生）、
+# トークン所有者自身を指す "@me" を使う。それも失敗した場合は
+# GraphQL API (addProjectV2ItemById) で直接追加する。
 name: Add issues to project
 
 on:
@@ -23,21 +28,21 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - name: Diagnose token (一時的な診断ステップ)
-        env:
-          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
-        run: |
-          echo "token prefix: ${GH_TOKEN:0:4} (ghp_=classic / gith=fine-grained / 空=未設定)"
-          echo "token length: ${#GH_TOKEN}"
-          echo "--- REST /user のレスポンスヘッダ ---"
-          curl -sS -D - -o /dev/null -H "Authorization: token $GH_TOKEN" https://api.github.com/user | grep -i -E '^(HTTP|x-oauth-scopes|github-authentication-token-type)' || true
-          echo "--- GraphQL user lookup ---"
-          gh api graphql -f query='query($login:String!){user(login:$login){id login}}' -F login=RTakayama1293 || true
       - name: Add issue to user project
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
         run: |
-          # workflow_dispatch時はissueコンテキストが無いのでテストIssueで代用
-          gh project item-add "$PROJECT_NUMBER" --owner RTakayama1293 \
-            --url "${ISSUE_URL:-https://github.com/RTakayama1293/snj-knowledge/issues/33}"
+          URL="${ISSUE_URL:-https://github.com/RTakayama1293/snj-knowledge/issues/33}"
+          if gh project item-add "$PROJECT_NUMBER" --owner "@me" --url "$URL"; then
+            exit 0
+          fi
+          echo "gh project item-add が失敗したため、GraphQLで直接追加する"
+          NODE_ID="${ISSUE_NODE_ID:-$(gh api repos/RTakayama1293/snj-knowledge/issues/33 --jq .node_id)}"
+          PROJECT_ID=$(gh api graphql \
+            -f query='query($login:String!,$number:Int!){user(login:$login){projectV2(number:$number){id}}}' \
+            -F login=RTakayama1293 -F number="$PROJECT_NUMBER" --jq '.data.user.projectV2.id')
+          gh api graphql \
+            -f query='mutation($project:ID!,$content:ID!){addProjectV2ItemById(input:{projectId:$project,contentId:$content}){item{id}}}' \
+            -F project="$PROJECT_ID" -F content="$NODE_ID"


### PR DESCRIPTION
## 概要

`unknown owner type` の修正。診断ラン（run 30774969108）で以下を確認済み。

- PATはclassic（`ghp_`・40文字）
- `x-oauth-scopes: project, repo` — scopeは正しく付与されている
- GraphQLの `user(login:"RTakayama1293")` 照会は成功する
- それでも `gh project item-add --owner RTakayama1293` のみ失敗する

→ secretやscopeの問題ではなく、ghコマンド内部のオーナー種別判定に限定された問題。

## 変更内容

- `--owner RTakayama1293` → `--owner "@me"`（トークン所有者自身を指す指定。内部のuser/org判定クエリを迂回する）
- それでも失敗した場合のフォールバックとして、GraphQL `addProjectV2ItemById` で直接Projectに追加する処理を追加
- 役目を終えた診断ステップ（トークン種別・scope出力）を削除

## 動作確認

マージ後にテストIssueを作成して発火確認する（こちらで実施）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gRkjZM28oBUjimR9DjqxF

---
_Generated by [Claude Code](https://claude.ai/code/session_016gRkjZM28oBUjimR9DjqxF)_